### PR TITLE
feat: robust unread cursor tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,15 @@ node dist/cli.js openclaw --payload '{"action":"send","chat":"-100123","text":"h
 - add dry-run simulation mode
 - add structured policy hooks (regex allow/deny)
 - add CI pipeline + tests
+
+## Cursor commands (unread tracking)
+
+```bash
+node dist/cli.js cursor:show --chat -1001234567890
+node dist/cli.js cursor:reset --chat -1001234567890
+```
+
+Unread tracking now stores per-chat cursor metadata:
+- `lastMessageId`
+- `lastTimestamp`
+- `lastRunAt`

--- a/src/checkpoint.ts
+++ b/src/checkpoint.ts
@@ -1,7 +1,13 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { dirname } from 'node:path';
 
-export type Checkpoint = Record<string, number>;
+export type Cursor = {
+  lastMessageId: number;
+  lastTimestamp?: string;
+  lastRunAt?: string;
+};
+
+export type Checkpoint = Record<string, Cursor>;
 
 function checkpointPath(): string {
   return process.env.TG_CHECKPOINT_PATH ?? '/data/checkpoint.json';
@@ -17,4 +23,10 @@ export function saveCheckpoint(cp: Checkpoint): void {
   const path = checkpointPath();
   mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, JSON.stringify(cp, null, 2));
+}
+
+export function resetCursor(chatId: string): void {
+  const cp = loadCheckpoint();
+  delete cp[chatId];
+  saveCheckpoint(cp);
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { hideBin } from 'yargs/helpers';
 import { loadConfig } from './config.js';
 import { authLogin, authStatus } from './auth.js';
 import { readLatest, readUnread, sendMessage } from './messages.js';
+import { loadCheckpoint, resetCursor } from './checkpoint.js';
 import { runOpenClawTool } from './openclaw.js';
 
 async function main() {
@@ -18,6 +19,8 @@ async function main() {
     .command('read', 'Read latest messages', (y) => y.option('chat', { type: 'string', demandOption: true }).option('limit', { type: 'number', default: 20 }), async (a) => readLatest(String(a.chat), Number(a.limit)))
     .command('unread', 'Read unread since checkpoint', (y) => y.option('chat', { type: 'string', demandOption: true }).option('limit', { type: 'number', default: 50 }), async (a) => readUnread(String(a.chat), Number(a.limit)))
     .command('send', 'Send message', (y) => y.option('chat', { type: 'string', demandOption: true }).option('text', { type: 'string', demandOption: true }), async (a) => sendMessage(String(a.chat), String(a.text)))
+    .command('cursor:show', 'Show cursor for a chat', (y)=> y.option('chat',{type:'string', demandOption:true}), async (a)=> { const cp=loadCheckpoint(); console.log(JSON.stringify({ok:true, chat:String(a.chat), cursor:cp[String(a.chat)] ?? null}, null, 2)); })
+    .command('cursor:reset', 'Reset cursor for a chat', (y)=> y.option('chat',{type:'string', demandOption:true}), async (a)=> { resetCursor(String(a.chat)); console.log(JSON.stringify({ok:true, chat:String(a.chat), reset:true}, null, 2)); })
     .command('openclaw', 'OpenClaw wrapper mode (JSON payload)', (y) => y.option('payload', { type: 'string', demandOption: true }), async (a) => runOpenClawTool(String(a.payload)))
     .demandCommand(1)
     .strict()


### PR DESCRIPTION
Closes #12\n\n- Per-chat cursor object (id/timestamp/run)\n- cursor:show and cursor:reset commands\n- improved unread output