### PR TITLE
feat: unread consume + mark-as-read

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ node dist/cli.js auth:status
 # read/send
 node dist/cli.js read --chat -1001234567890 --limit 20
 node dist/cli.js unread --chat -1001234567890 --limit 50
+node dist/cli.js unread:consume --chat -1001234567890 --limit 50
 node dist/cli.js send --chat -1001234567890 --text "hello"
 ```
+
+`unread:consume` returns unread messages and marks them as read in Telegram, then advances the DB cursor.
 
 ## Docker usage
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { loadConfig } from './config.js';
 import { authLogin, authStatus } from './auth.js';
-import { readLatest, readUnread, sendMessage } from './messages.js';
+import { readLatest, readUnread, unreadConsume, sendMessage } from './messages.js';
 import { getCursor, resetCursor } from './checkpoint.js';
 import { runOpenClawTool } from './openclaw.js';
 import { runWebhookServer, consumeWebhookQueue } from './webhook.js';
@@ -33,6 +33,12 @@ async function main() {
       'Read unread since checkpoint',
       (y) => y.option('chat', { type: 'string', demandOption: true }).option('limit', { type: 'number', default: 50 }),
       async (a) => readUnread(String(a.chat), Number(a.limit))
+    )
+    .command(
+      'unread:consume',
+      'Return unread messages and mark them read',
+      (y) => y.option('chat', { type: 'string', demandOption: true }).option('limit', { type: 'number', default: 50 }),
+      async (a) => unreadConsume(String(a.chat), Number(a.limit))
     )
     .command(
       'send',

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,6 +1,32 @@
+import { Api } from 'telegram';
 import { createClient } from './telegram-client.js';
 import { canSend } from './policy.js';
 import { getCursor, setCursor } from './checkpoint.js';
+
+type MessageOut = { id: number | undefined; text: string | undefined; date: unknown };
+
+async function fetchUnread(chatId: string, limit: number): Promise<{ minId: number; maxId: number; unread: MessageOut[] }> {
+  const cursor = await getCursor(chatId);
+  const minId = cursor?.lastMessageId ?? 0;
+  const client = await createClient();
+  const msgs = await client.getMessages(chatId, { limit });
+  const unread = msgs
+    .filter((m) => (m.id ?? 0) > minId)
+    .map((m) => ({ id: m.id, text: m.message, date: m.date }))
+    .reverse();
+  const maxId = unread.reduce((acc, m) => Math.max(acc, Number(m.id ?? 0)), minId);
+  await client.disconnect();
+  return { minId, maxId, unread };
+}
+
+async function persistCursor(chatId: string, maxId: number, unread: MessageOut[]): Promise<void> {
+  const cursor = await getCursor(chatId);
+  await setCursor(chatId, {
+    lastMessageId: maxId,
+    lastTimestamp: unread.length ? String(unread[unread.length - 1].date ?? '') : cursor?.lastTimestamp,
+    lastRunAt: new Date().toISOString()
+  });
+}
 
 export async function readLatest(chatId: string, limit: number): Promise<void> {
   const client = await createClient();
@@ -11,26 +37,32 @@ export async function readLatest(chatId: string, limit: number): Promise<void> {
 }
 
 export async function readUnread(chatId: string, limit: number): Promise<void> {
+  const { minId, maxId, unread } = await fetchUnread(chatId, limit);
+  await persistCursor(chatId, maxId, unread);
   const cursor = await getCursor(chatId);
-  const minId = cursor?.lastMessageId ?? 0;
-  const client = await createClient();
-  const msgs = await client.getMessages(chatId, { limit });
-  const unread = msgs
-    .filter((m) => (m.id ?? 0) > minId)
-    .map((m) => ({ id: m.id, text: m.message, date: m.date }))
-    .reverse();
+  console.log(JSON.stringify({ ok: true, minId, maxId, cursor, count: unread.length, messages: unread }, null, 2));
+}
 
-  const maxId = unread.reduce((acc, m) => Math.max(acc, Number(m.id ?? 0)), minId);
-  const nextCursor = {
-    lastMessageId: maxId,
-    lastTimestamp: unread.length ? String(unread[unread.length - 1].date ?? '') : cursor?.lastTimestamp,
-    lastRunAt: new Date().toISOString()
-  };
+export async function unreadConsume(chatId: string, limit: number): Promise<void> {
+  const { minId, maxId, unread } = await fetchUnread(chatId, limit);
 
-  await setCursor(chatId, nextCursor);
+  // mark as read in Telegram when we consumed unread payload
+  if (unread.length > 0 && maxId > minId) {
+    const client = await createClient();
+    const peer = await client.getInputEntity(chatId);
+    await client.invoke(new Api.messages.ReadHistory({ peer, maxId }));
+    await client.disconnect();
+  }
 
-  console.log(JSON.stringify({ ok: true, minId, maxId, cursor: nextCursor, count: unread.length, messages: unread }, null, 2));
-  await client.disconnect();
+  await persistCursor(chatId, maxId, unread);
+  const cursor = await getCursor(chatId);
+  console.log(
+    JSON.stringify(
+      { ok: true, consumed: true, markedRead: unread.length > 0, minId, maxId, cursor, count: unread.length, messages: unread },
+      null,
+      2
+    )
+  );
 }
 
 export async function sendMessage(chatId: string, text: string): Promise<void> {


### PR DESCRIPTION
Closes #17\n\n- Added unread:consume command\n- Marks Telegram history as read\n- Persists cursor after consume